### PR TITLE
Fix CRM-21348

### DIFF
--- a/CRM/Profile/Selector/Listings.php
+++ b/CRM/Profile/Selector/Listings.php
@@ -506,7 +506,7 @@ class CRM_Profile_Selector_Listings extends CRM_Core_Selector_Base implements CR
     if ($editLink && ($mask & CRM_Core_Permission::EDIT)) {
       // do not allow edit for anon users in joomla frontend, CRM-4668
       $config = CRM_Core_Config::singleton();
-      if (!$config->userFrameworkFrontend) {
+      if (!$config->userFrameworkFrontend || CRM_Core_Session::singleton()->getLoggedInContactID()) {
         $this->_editLink = TRUE;
       }
     }


### PR DESCRIPTION
Don't hide the "edit" link from logged-in users in profile listings in joomla front-end.

Overview
----------------------------------------
CiviCRM hides the "edit" link in profile search results for logged in users, if in the Joomla front end.  Seems like if the user is logged in, and has permissions to access the "edit" link, we should allow it.

Before
----------------------------------------
Edit link is hidden.

After
----------------------------------------
Edit link is displayed.

Technical Details
----------------------------------------
None.

Comments
----------------------------------------
None.